### PR TITLE
Add conversation storage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ Hi there 👋
 😄 Pronouns: He/Him.
 
 ⚡ Fun fact: I'm convinced that understanding human psychology is often the key to both the best offense and the strongest defense in cybersecurity.
+
+## Conversatie Opslag Script
+
+In de map `scripts` staat `saveConversations.js`. Dit script slaat een array van gesprekken op als een Markdown-bestand. Elk gesprek krijgt een titel (niveau 1 kop) gevolgd door alle berichten met de auteur als niveau 2 kop.
+
+Gebruik het script via Node:
+
+```bash
+node scripts/saveConversations.js
+```
+
+Het voorbeeld in het script maakt een `gesprekken.md` bestand aan in de hoofdmap.

--- a/scripts/saveConversations.js
+++ b/scripts/saveConversations.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+
+/**
+ * Save an array of conversations as a Markdown file.
+ * Each conversation is rendered with a level 1 heading for the title
+ * followed by level 2 headings for each message author and the message text.
+ *
+ * @param {string} filename - The path where the Markdown file will be saved.
+ * @param {Array<Object>} conversations - The conversations to save.
+ *        Each object should have a `title` and a `messages` array with
+ *        items of the form `{ author: string, text: string }`.
+ */
+function saveConversations(filename, conversations) {
+  let mdContent = '';
+
+  conversations.forEach((conversation) => {
+    mdContent += `# ${conversation.title}\n\n`;
+
+    conversation.messages.forEach((msg) => {
+      mdContent += `## ${msg.author}\n`;
+      mdContent += `${msg.text}\n\n`;
+    });
+  });
+
+  fs.writeFileSync(filename, mdContent, 'utf8');
+}
+
+// Example usage
+if (require.main === module) {
+  const data = [
+    {
+      title: 'Demo-Gesprek 1',
+      messages: [
+        { author: 'Gebruiker', text: 'Hallo!' },
+        { author: 'Bot', text: 'Hi, hoe kan ik je helpen?' }
+      ]
+    },
+    {
+      title: 'Demo-Gesprek 2',
+      messages: [
+        { author: 'Gebruiker', text: 'Wat is het weer vandaag?' },
+        { author: 'Bot', text: 'Het wordt zonnig met 23°C.' }
+      ]
+    }
+  ];
+
+  saveConversations('gesprekken.md', data);
+  console.log('Conversaties opgeslagen in gesprekken.md');
+}
+
+module.exports = saveConversations;


### PR DESCRIPTION
## Summary
- add `saveConversations.js` script for saving conversations to Markdown
- document usage in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_687e376bfa80832bb794e1a359277e79